### PR TITLE
fix: prospector slow speed

### DIFF
--- a/python/prospector.sh
+++ b/python/prospector.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-python -m prospector -M
+# Prospector is really slow for some reason scanning a repo with a lot of files.
+# So use find and xargs to run it.
+find . -name "*.py" | xargs python -m prospector -M
 


### PR DESCRIPTION
Use `find` and `xargs` to target `.py` files only. Prospector seems to be massively slower when scanning the repo itself.